### PR TITLE
Display list of all Companies (new CI)

### DIFF
--- a/Kernel/Output/HTML/ITSMConfigItem/LayoutCustomerCompany.pm
+++ b/Kernel/Output/HTML/ITSMConfigItem/LayoutCustomerCompany.pm
@@ -141,7 +141,9 @@ sub InputCreate {
     }
 
     # get class list
-    my %CompanyList = $Kernel::OM->Get('Kernel::System::CustomerCompany')->CustomerCompanyList();
+    my %CompanyList = $Kernel::OM->Get('Kernel::System::CustomerCompany')->CustomerCompanyList(
+        Limit => 0,                 # Display all Customer Companies
+    );
 
     # generate string
     my $String = $Kernel::OM->Get('Kernel::Output::HTML::Layout')->BuildSelection(


### PR DESCRIPTION
When user adds new CI and it contains CustomerCompany field, it should show all companies in the drop-down. If there is no Limit parameter, system will pull Limit from ZZZCustomerInformation.pm (CustomerUserSearchListLimit), and display list of only 250 customers. The result is that users can't create CI bound to missing customers. Currently we have ~700 customers, which means 500 are missing!

If you have any questions, please contact me.
PS. I didn't check other modules, it's possible that they contain similar mistake(s).
